### PR TITLE
Run tests on PRs using GitHub Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,7 +10,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Now that we have tests, let's automatically run them on PRs. That way we won't have to do it manually, and we can configure github to require them to pass before merging, so we don't accidentally release known-broken changes.

Adapted from the template generated by https://github.com/roosto/bikebus-nyc/new/main?filename=.github%2Fworkflows%2Fnode.js.yml&workflow_template=ci%2Fnode.js

Uses the caching/installation technique from https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data

You can see an example of it working here: https://github.com/roosto/bikebus-nyc/actions/runs/15197772410/job/42745858352?pr=14#step:5:85