### PR TITLE
Update for `bergen-to-court` portion of `bergen` route

### DIFF
--- a/routes/bergen-to-court.json
+++ b/routes/bergen-to-court.json
@@ -3,7 +3,7 @@
       "color" : "#EFB143",
       "mapHeight" : "250px",
       "mapWidth" : "550px",
-      "runInfo" : "Track the bike bus live on the map above beginning at 7:00am every Wednesday morning.",
+      "runInfo" : "Track the bike bus live on the map above beginning at 7:15am every Wednesday morning.",
       "publish" : false,
       "stops" : [
          {

--- a/routes/bergen-to-court.json
+++ b/routes/bergen-to-court.json
@@ -12,31 +12,55 @@
                -73.91115
             ],
             "markerClass" : "rotate-65",
-            "name" : "Rockaway Av",
+            "name" : "Rockaway Ave @ Bergen",
             "subtitle" : "",
-            "time" : "7:05 - 7:20"
+            "time" : "7:15-7:20"
          },
          {
             "coordinates" : [
-               40.674435,
-               -73.91946
+               40.674448,
+               -73.919458
             ],
             "markerClass" : "rotate-65",
-            "name" : "Howard Av",
-            "subtitle" : "",
+            "name" : "Howard Ave",
+            "time" : "",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.676007, -73.919316
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Howard Ave @ Pacific",
             "time" : "7:25"
          },
          {
             "coordinates" : [
-               40.674895,
-               -73.927767
+40.676329, -73.925284
             ],
             "markerClass" : "rotate-65",
-            "name" : "Rochester Av",
+            "name" : "Kingsborough Houses",
+            "time" : ""
+         },
+         {
+            "coordinates" : [
+40.674783, -73.925458
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Kingsborough Houses @ Bergen",
+            "time" : "",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.675050, -73.930545
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Utica Ave @ Bergen",
             "subtitle" : "",
             "time" : "7:30"
          },
-         {
+                  {
             "coordinates" : [
                40.675787,
                -73.94439
@@ -48,13 +72,33 @@
          },
          {
             "coordinates" : [
+40.676250, -73.952636
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Rogers Ave",
+            "subtitle" : "",
+            "time" : "",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.676271, -73.953047
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Bedford Ave",
+            "subtitle" : "",
+            "time" : "7:40"
+         },
+         {
+            "coordinates" : [
                40.677523,
                -73.959131
             ],
             "markerClass" : "rotate-65",
             "name" : "Classon Av",
             "subtitle" : "",
-            "time" : "7:40"
+            "time" : "",
+            "waypointOnly": true
          },
          {
             "coordinates" : [
@@ -122,8 +166,9 @@
                40.685023,
                -73.986139
             ],
-            "markerClass" : "rotate-65 label-left push-up-6x",
-            "name" : "Bond St",
+            "markerClass" : "rotate-65",
+            "name": "",
+            "time" : "Bond St",
             "subtitle" : ""
          },
          {

--- a/routes/bergen-to-ps372.json
+++ b/routes/bergen-to-ps372.json
@@ -3,7 +3,7 @@
       "color" : "#EFB143",
       "mapHeight" : "250px",
       "mapWidth" : "550px",
-      "runInfo" : "Track the bike bus live on the map above beginning at 7:00am every Wednesday morning.",
+      "runInfo" : "Track the bike bus live on the map above beginning at 7:15am every Wednesday morning.",
       "publish" : false,
       "stops" : [
          {

--- a/routes/bergen.json
+++ b/routes/bergen.json
@@ -4,7 +4,7 @@
       "mapHeight" : "250px",
       "mapWidth" : "550px",
       "publish" : true,
-      "runInfo" : "Track the bike bus live on the map above beginning at 7:00am every Wednesday morning.",
+      "runInfo" : "Track the bike bus live on the map above beginning at 7:15am every Wednesday morning.",
       "title" : "Bergen Bike Bus",
       "trackerBounds" : {
          "bottomLeft" : [

--- a/src/pages/tracker.hbs
+++ b/src/pages/tracker.hbs
@@ -166,8 +166,9 @@
         </h1>
         <div id="map"></div>
         <h2 id="info">
-          {{route.runInfo}}
-           Brought to you by <a href="https://bikebus.nyc/">bikebus.nyc</a>
+          {{route.runInfo}}<br />
+          Times shown on map are <em>estimates</em>; day of location of the Bike Bus is in real time<br />
+          Brought to you by <a href="https://bikebus.nyc/">bikebus.nyc</a>
         </h2>
         <!-- stop markers -->
         {{#each routes}}


### PR DESCRIPTION
After joining the Bike Bus from the beginning of the route this week, and using the new tracker for the first time, I realized that there are some changes to the route that we needed to make.

* add northward jog onto Pacific St from Howard to Buffalo
* add stop name for Kingsborough Houses
* move 7:25 stop from Rochester to Utica, to reduce visual clutter w/ Kingsborough Houses stop, and to move to an Avenue that has a subway stop of the same name
* move 7:40 stop from Classon Ave to Bedford Ave, so that the stops are better spaced apart
* Move `Bond St` label into `time` field so that it is less visually cluttered (this a bad idea, and a quick fix; we need a follow up task to create a new CSS rule to hand this. As it is, this change violates the semantics of the JSON)