### PR TITLE
Beacon pages for meta routes offer links to branches

### DIFF
--- a/routes/bergen-to-court.json
+++ b/routes/bergen-to-court.json
@@ -6,6 +6,7 @@
       "runInfo" : "Track the bike bus live on the map above beginning at 7:00am every Wednesday morning.",
       "publish" : false,
       "title" : "Bergen Bike Bus: Court St Branch",
+      "parentMetaRoute": "bergen",
       "stops" : [
          {
             "coordinates" : [

--- a/routes/bergen-to-court.json
+++ b/routes/bergen-to-court.json
@@ -5,6 +5,7 @@
       "mapWidth" : "550px",
       "runInfo" : "Track the bike bus live on the map above beginning at 7:00am every Wednesday morning.",
       "publish" : false,
+      "title" : "Bergen Bike Bus: Court St Branch",
       "stops" : [
          {
             "coordinates" : [
@@ -137,7 +138,6 @@
             "time" : "8:05"
          }
       ],
-      "title" : "Bergen Bike Bus Tracker",
       "trackerBounds" : {
          "bottomLeft" : [
             40.685828,

--- a/routes/bergen-to-ps372.json
+++ b/routes/bergen-to-ps372.json
@@ -6,6 +6,7 @@
       "runInfo" : "Track the bike bus live on the map above beginning at 7:00am every Wednesday morning.",
       "publish" : false,
       "title" : "Bergen Bike Bus: PS 372 Branch",
+      "parentMetaRoute": "bergen",
       "stops" : [
          {
             "coordinates" : [

--- a/routes/bergen-to-ps372.json
+++ b/routes/bergen-to-ps372.json
@@ -5,6 +5,7 @@
       "mapWidth" : "550px",
       "runInfo" : "Track the bike bus live on the map above beginning at 7:00am every Wednesday morning.",
       "publish" : false,
+      "title" : "Bergen Bike Bus: PS 372 Branch",
       "stops" : [
          {
             "coordinates" : [
@@ -47,7 +48,6 @@
             "time" : "8:05"
          }
       ],
-      "title" : "Bergen Bike Bus Tracker",
       "trackerBounds" : {
          "bottomLeft" : [
             40.685828,

--- a/server.js
+++ b/server.js
@@ -122,6 +122,18 @@ server.get(
       return reply.code(404).type("text/plain").send("Route not found.");
     }
 
+    // no such thing as a beacon page for a "meta route"
+    // send user to a page where they can the go to the correct route
+    if (routes[routeKey].hasOwnProperty('combinedRouteKeys')) {
+      const routeKeys = routes[routeKey].combinedRouteKeys
+      const params = {
+        beacon_hash: process.env.beacon_hash,
+        routeKeys: routeKeys,
+        routes: filterObj.includeKeys(routes, routeKeys)
+      }
+      return reply.view("/src/pages/beacon-choice.hbs", params);
+    }
+
     const params = {
       beacon_hash: process.env.beacon_hash,
       routeKey: routeKey,

--- a/server.js
+++ b/server.js
@@ -134,9 +134,12 @@ server.get(
       return reply.view("/src/pages/beacon-choice.hbs", params);
     }
 
+    const iframeRouteKey = routes[routeKey].hasOwnProperty('parentMetaRoute') ? routes[routeKey].parentMetaRoute : routeKey
     const params = {
       beacon_hash: process.env.beacon_hash,
       routeKey: routeKey,
+      iframeRouteKey: iframeRouteKey,
+      hasParentMetaRoute: routeKey != iframeRouteKey,
     };
     return reply.view("/src/pages/beacon.hbs", params);
   }

--- a/src/pages/beacon-choice.hbs
+++ b/src/pages/beacon-choice.hbs
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    
+    <!-- 
+      This is the main Handlebars template for the site 
+      - When the user visits the homepage or submits a color the app calls the endpoints in main.js
+      - The server script passes data in here and the Handlebars code builds it into the HTML page
+    -->
+    
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  
+    <title>Bike Bus Beacon</title> 
+    
+    <style>
+      div#conductor-header {
+        background-color:white;
+        width:100%;
+        position:fixed;
+        height: 175px;
+        top: 0;
+      }
+      div#conductor-header-spaceholder {
+        height:195px;
+        padding-top: 0;
+      }
+      iframe#tracker {
+        height: 900px;
+        width: 100%;
+      }
+      
+      h1 span.clock {
+          font-size:2em;  
+      }
+      
+      span#clock-seconds {
+        color: grey;
+      }
+      
+      div.tracking-error {
+        display: none;
+      }
+      
+      div.tracking-error.has-error {
+        display: block;
+        background-color: white;
+        width:100%;
+        height: 900px;
+        position: absolute;
+      }
+      
+        div.tracking-error.has-error h2{
+          font-size: 2em;
+          color: red;
+      }
+      
+    </style>
+  </head>
+  <body>
+        <!-- This is the start of content for our page --> 
+      <div id="conductor-header">
+        <h1 class="title">Choose your Bike Bus Branch</h1>
+          <div class="tracking-error has-error" id="location-error-message-container">
+          <h2>
+            Not tracking.
+          </h2>
+          <p>
+            This Bike Bus has multiple branches. For which branch are you broadcasting location? 
+          </p>
+
+          <ol>
+          {{#each routes}}
+            <li><a href="../{{@key}}/{{../beacon_hash}}"><tt>{{@key}}:</tt> {{this.title}}</a></li>
+          {{/each}}
+          </ol> 
+          <p>
+            Still not working? Find <a href="/beacon-instructions">more troubleshooting ideas here</a>.
+          </p>
+        </div>
+  </body>
+</html>

--- a/src/pages/beacon.hbs
+++ b/src/pages/beacon.hbs
@@ -11,7 +11,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   
-    <title>Bike Bus Beacon</title> 
+    <title>Bike Bus Beacon for {{routeKey}}</title> 
     
     <style>
       div#conductor-header {
@@ -60,9 +60,7 @@
   <body>
         <!-- This is the start of content for our page --> 
       <div id="conductor-header">
-        <h1 class="title">
-          Bike Bus Beacon <br />
-        </h1>
+        <h1 class="title">Bike Bus Beacon for: <tt>{{routeKey}}</tt></h1>
           <div class="tracking-error" id="location-error-message-container">
           <h2>
             Not tracking.
@@ -95,7 +93,12 @@
         </div>
     
         <div id="conductor-header-spaceholder"></div>
-        <iframe id="tracker" src="/{{routeKey}}"> </iframe>
+        <h3>The below is a preview of the tracking page for the
+          {{#if hasParentMetaRoute}}
+          parent
+          {{/if}}
+          route: <tt>{{iframeRouteKey}}</tt></h3>
+        <iframe id="tracker" src="/{{iframeRouteKey}}"> </iframe>
         
       
         <!-- beacon.js -->

--- a/src/pages/beacon.hbs
+++ b/src/pages/beacon.hbs
@@ -75,7 +75,7 @@
             </p>
               <ol>
                 <li>Open your <b>Settings</b> app</li>
-                <li>Go to <b>Privacy &amp; Security</b> &gt <b>Location Services</b> &gt <b>Safari Websites</b></li>
+                <li>Go to <b>Privacy &amp; Security</b> &gt; <b>Location Services</b> &gt; <b>Safari Websites</b></li>
                 <li>Choose <b>While Using the App</b></li>
                 <li>Refresh this page and accept the location sharing prompt.</li>
             </ol>

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -83,6 +83,19 @@ test(`requests the beacon page, with a hash, at: \`/beacon/mcs/${process.env.bea
   t.equal(response.statusCode, 200, 'returns a status code of 200')
 })
 
+test(`requests the beacon page for a "meta" route at: \`/beacon/bergen/${process.env.beacon_hash}\` route`, async t => {
+  const response = await server.inject({
+    method: 'GET',
+    url: `/beacon/bergen/${process.env.beacon_hash}`
+  })
+  t.equal(response.statusCode, 200, 'returns a status code of 200')
+  t.match(response.body, /<h1[^>]*>Choose your Bike Bus Branch<\/h1>/)
+  let regex_pattern = new RegExp('<a href="[^"]+/bergen-to-ps372/' + process.env.beacon_hash)
+  t.match(response.body, regex_pattern)
+  regex_pattern = new RegExp('<a href="[^"]+/bergen-to-court/' + process.env.beacon_hash)
+  t.match(response.body, regex_pattern)
+})
+
 test(`POST and GET location for \`mcs\` route`, async t => {
   const location = { latitude: 40.803917, longitude: -73.946054 }
   const post_response = await server.inject({

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -81,6 +81,9 @@ test(`requests the beacon page, with a hash, at: \`/beacon/mcs/${process.env.bea
     url: `/beacon/mcs/${process.env.beacon_hash}`
   })
   t.equal(response.statusCode, 200, 'returns a status code of 200')
+  t.match(response.body, /Bike +Bus +Beacon +for: +<tt>mcs/)
+  t.match(response.body, /tracking +page +for +the\s+route: +<tt>mcs/)
+  t.match(response.body, /<iframe[^>]+src="\/mcs"/)
 })
 
 test(`requests the beacon page for a "meta" route at: \`/beacon/bergen/${process.env.beacon_hash}\` route`, async t => {
@@ -94,6 +97,17 @@ test(`requests the beacon page for a "meta" route at: \`/beacon/bergen/${process
   t.match(response.body, regex_pattern)
   regex_pattern = new RegExp('<a href="[^"]+/bergen-to-court/' + process.env.beacon_hash)
   t.match(response.body, regex_pattern)
+})
+
+test(`requests the beacon page for branch of a "meta" route, with a hash, at: \`/beacon/bergen-to-ps372/${process.env.beacon_hash}\` route`, async t => {
+  const response = await server.inject({
+    method: 'GET',
+    url: `/beacon/bergen-to-ps372/${process.env.beacon_hash}`
+  })
+  t.equal(response.statusCode, 200, 'returns a status code of 200')
+  t.match(response.body, /Bike +Bus +Beacon +for: +<tt>bergen-to-ps372/)
+  t.match(response.body, /tracking +page +for +the\s+parent\s+route: +<tt>bergen/)
+  t.match(response.body, /<iframe[^>]+src="\/bergen"/)
 })
 
 test(`POST and GET location for \`mcs\` route`, async t => {


### PR DESCRIPTION
This fixes #27 (edited so that the issue will be closed when this is merged, see https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue)

1. beacon pages for meta routes now present a page with a choice of possible branches to use.
2. beacon pages for branches of a "meta" route now display the tracker for the meta route in the page's `iframe`
3. route JSON for branch routes of a "meta" route now have a `parentMetaRoute` key that is used for the `src` attribute of the `iframe` on the beacon page
4. beacon pages state the branch route, but also make it clear the the preview is for the parent route
5. tests are updated to test for these scenarios

