### PR TITLE
Keep screen on so app stays in foreground and continues publishing beacons

### DIFF
--- a/src/pages/beacon.hbs
+++ b/src/pages/beacon.hbs
@@ -216,5 +216,16 @@
             }
             clock();
         </script>
+        <script src="https://unpkg.com/nosleep.js@0.12.0/dist/NoSleep.min.js" integrity="sha384-lp0XiAMtqqqjyVLBYjAcDQzxc2XyGj3sGESoiWbccHdpXjNUPUjWrq5GMqaGHGp9" crossorigin="anonymous"></script>
+        <script>
+          var noSleep = new NoSleep();
+          // Enable wake lock.
+          // (must be wrapped in a user input event handler e.g. a mouse or touch handler)
+          document.addEventListener('click', function enableNoSleep() {
+            document.removeEventListener('click', enableNoSleep, false);
+            noSleep.enable();
+            console.log("wake lock enabled")
+          }, false);
+        </script>
   </body>
 </html>

--- a/src/pages/beacon.hbs
+++ b/src/pages/beacon.hbs
@@ -85,6 +85,11 @@
           <span class="clock" id="clock-hours-minutes"></span><span class="clock" id="clock-seconds"></span>
         </h2>
         
+        <input type="button" id="toggle" value="Keep phone awake and screen on" />
+
+        <br/>
+        <br/>
+
         <label>
           <input type="checkbox" id="publish-location-checkbox" checked/> Publish location
         </label>
@@ -219,15 +224,23 @@
             }
             clock();
         </script>
+
         <script src="https://unpkg.com/nosleep.js@0.12.0/dist/NoSleep.min.js" integrity="sha384-lp0XiAMtqqqjyVLBYjAcDQzxc2XyGj3sGESoiWbccHdpXjNUPUjWrq5GMqaGHGp9" crossorigin="anonymous"></script>
         <script>
           var noSleep = new NoSleep();
-          // Enable wake lock.
-          // (must be wrapped in a user input event handler e.g. a mouse or touch handler)
-          document.addEventListener('click', function enableNoSleep() {
-            document.removeEventListener('click', enableNoSleep, false);
-            noSleep.enable();
-            console.log("wake lock enabled")
+
+          var wakeLockEnabled = false;
+          var toggleEl = document.querySelector("#toggle");
+          toggleEl.addEventListener('click', function() {
+            if (!wakeLockEnabled) {
+              noSleep.enable(); // keep the screen on!
+              wakeLockEnabled = true;
+              toggleEl.value = "Allow screen to turn off and phone to sleep";
+            } else {
+              noSleep.disable(); // let the screen turn off.
+              wakeLockEnabled = false;
+              toggleEl.value = "Keep phone awake and screen on";
+            }
           }, false);
         </script>
   </body>


### PR DESCRIPTION
Fixes https://github.com/roosto/bikebus-nyc/issues/15:

> One current problem is that phones will turn their screens off and put
> the app in the background, which stops the timer that periodically
> updates the beacon position
>
> We can use [richtr/NoSleep.js](https://github.com/richtr/NoSleep.js)
> to fix this, based on one test on [@roosto](https://github.com/roosto)'s
> iPhone.