### PR TITLE
Ignore trailing slashes in URLs to fix redirect from Glitch

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const filterObj = require('filter-obj')
 const server = require("fastify")({
   // Set this to true for detailed logging:
   logger: false,
+  ignoreTrailingSlash: true,
 });
 
 const storage = require("node-persist");

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -27,22 +27,20 @@ test('requests the `/mcs` route', async t => {
   t.match(response.body, /routes\s*=\s*\{\s*"mcs"\s*:\s*\{/, "Route JSON for `mcs` is embedded in page body")
 })
 
+test('requests the `/mcs/` route with a trailing slash', async t => {
+  const response = await server.inject({
+    method: 'GET',
+    url: '/mcs'
+  })
+  t.equal(response.statusCode, 200, 'returns a status code of 200')
+  t.match(response.body,  /<[hH]1>\s*MCS Bike Bus/, "<h1> tag contents match 'MCS Bike Bus")
+  t.match(response.body, /routes\s*=\s*\{\s*"mcs"\s*:\s*\{/, "Route JSON for `mcs` is embedded in page body")
+})
+
 test('requests the `/bergen` "meta" route', async t => {
   const response = await server.inject({
     method: 'GET',
     url: '/bergen'
-  })
-  t.equal(response.statusCode, 200, 'returns a status code of 200')
-  t.match(response.body, /<[hH]1>\s*Bergen Bike Bus/, "<h1> tag contents match 'Bergen Bike Bus'")
-  t.match(response.body, /routes\s*=\s*\{\s*"bergen-to-court"\s*:\s*\{/, "Route JSON is embedded in page body")
-  t.match(response.body, /trackBusLocation\('bergen-to-court'\)/, 'Sets up GET calls for `bergen-to-court` location endpoint')
-  t.match(response.body, /trackBusLocation\('bergen-to-ps372'\)/, 'Sets up GET calls for `bergen-to-ps378` location endpoint')
-})
-
-test('requests the `/bergen/` "meta" route with a trailing slash', async t => {
-  const response = await server.inject({
-    method: 'GET',
-    url: '/bergen/'
   })
   t.equal(response.statusCode, 200, 'returns a status code of 200')
   t.match(response.body, /<[hH]1>\s*Bergen Bike Bus/, "<h1> tag contents match 'Bergen Bike Bus'")

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -30,7 +30,7 @@ test('requests the `/mcs` route', async t => {
 test('requests the `/mcs/` route with a trailing slash', async t => {
   const response = await server.inject({
     method: 'GET',
-    url: '/mcs'
+    url: '/mcs/'
   })
   t.equal(response.statusCode, 200, 'returns a status code of 200')
   t.match(response.body,  /<[hH]1>\s*MCS Bike Bus/, "<h1> tag contents match 'MCS Bike Bus")

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -39,6 +39,18 @@ test('requests the `/bergen` "meta" route', async t => {
   t.match(response.body, /trackBusLocation\('bergen-to-ps372'\)/, 'Sets up GET calls for `bergen-to-ps378` location endpoint')
 })
 
+test('requests the `/bergen/` "meta" route with a trailing slash', async t => {
+  const response = await server.inject({
+    method: 'GET',
+    url: '/bergen/'
+  })
+  t.equal(response.statusCode, 200, 'returns a status code of 200')
+  t.match(response.body, /<[hH]1>\s*Bergen Bike Bus/, "<h1> tag contents match 'Bergen Bike Bus'")
+  t.match(response.body, /routes\s*=\s*\{\s*"bergen-to-court"\s*:\s*\{/, "Route JSON is embedded in page body")
+  t.match(response.body, /trackBusLocation\('bergen-to-court'\)/, 'Sets up GET calls for `bergen-to-court` location endpoint')
+  t.match(response.body, /trackBusLocation\('bergen-to-ps372'\)/, 'Sets up GET calls for `bergen-to-ps378` location endpoint')
+})
+
 test('requests the `/I-AM-NOT_HERE` route', async t => {
   const response = await server.inject({
     method: 'GET',


### PR DESCRIPTION
Fixes https://github.com/roosto/bikebus-nyc/issues/33:

> I was just checking out [#29](https://github.com/roosto/bikebus-nyc/issues/29), and found that the redirect from glitch isn't quite working properly: When I visit [bergenbiketrain.glitch.me](https://bergenbiketrain.glitch.me/), I get redirected to `https://tracker.bikebus.nyc/bergen/`, which gives a 404:

> <img alt="Image" width="526" src="https://private-user-images.githubusercontent.com/6473925/453188180-79b27d34-5ff5-419f-a5ba-276de0c40ee3.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDk1MDI3MzIsIm5iZiI6MTc0OTUwMjQzMiwicGF0aCI6Ii82NDczOTI1LzQ1MzE4ODE4MC03OWIyN2QzNC01ZmY1LTQxOWYtYTViYS0yNzZkZTBjNDBlZTMucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDYwOSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTA2MDlUMjA1MzUyWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9ZmIxZjgwZjQxMTg1ZGMwMjhkMmYxYWE2NmUxZWMxM2Y0NTRiNWY4Yzk3ZjdlY2Y2NTFlMzc3M2ZiYTc2Njc0NyZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.OLvm_-1LxcbfoTLw26XVXGA7BoDef0AtXXvvYVIow6c">
> 
> However, when I remove the trailing slash and visit [tracker.bikebus.nyc/bergen](https://tracker.bikebus.nyc/bergen), things work as expected:

> <img alt="Image" width="1728" src="https://private-user-images.githubusercontent.com/6473925/453188662-98a589de-30de-40bd-b055-c8de096dcc39.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDk1MDI3MzIsIm5iZiI6MTc0OTUwMjQzMiwicGF0aCI6Ii82NDczOTI1LzQ1MzE4ODY2Mi05OGE1ODlkZS0zMGRlLTQwYmQtYjA1NS1jOGRlMDk2ZGNjMzkucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDYwOSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTA2MDlUMjA1MzUyWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9OTQ1NDAyOGE4M2M2OTNlNTAzZDI2ZDdiZGEwNTUyNzNhNGQ3NjQyMGEyMzQwNjU3ZWRjMTExMDYwNDRjZWU3YSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.vRvEgXV-n0w1Z6aGBsfNaQ3L2yHCHYEOncnInHkDnw0">
> 
> So, I think we need to do at least one of the following:
> 
> * Update the Glitch redirect to go to `https://tracker.bikebus.nyc/bergen` instead of [tracker.bikebus.nyc/bergen](https://tracker.bikebus.nyc/bergen/)
> 
> * Update tracker.bikebus.nyc to handle the trailing slash (this is probably a good idea regardless of whether the redirect is updated)

To fix this, I searched for `fastify trailing slash` and found
https://github.com/fastify/fastify/discussions/3827, which linked to the
Fastify documentation of the option that does exactly this:
https://fastify.dev/docs/latest/Reference/Server/#ignoretrailingslash