### PR TITLE
Fixes for redirects from glitch's beacon page

### DIFF
--- a/server.js
+++ b/server.js
@@ -115,6 +115,15 @@ server.get("/beacon-instructions", async function (request, reply) {
   return reply.view("/src/pages/tracker-instructions.hbs", params);
 });
 
+// this handles the case where the beacon page on the glitch app redirects to us
+// we send the redirection straight to the `bergen-to-court` route, b/c it's confusing otherwise
+server.get(
+  "/bergen/beacon/bergen/:beacon_hash", async function (request, reply) {
+    const { beacon_hash } = request.params;
+    return reply.redirect('/beacon/bergen-to-court/' + encodeURI(beacon_hash), 301);
+  }
+);
+
 server.get(
   "/beacon/:routeKey/" + process.env.beacon_hash,
   function (request, reply) {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -76,6 +76,15 @@ test('requests the beacon page, w/a bogus routeKey, at: `/beacon/I-AM-NOT-HERE/`
   t.match(response.body, /not found/i)
 })
 
+test('requests the bergen beacon page with the prefix `/bergen` at:`/bergen/beacon/bergen/{token}`', async t => {
+  const response = await server.inject({
+    method: 'GET',
+    url: '/bergen/beacon/bergen/fsdakjhfdsjh'
+  })
+  t.equal(response.statusCode, 301, 'returns a status code of 301')
+  t.match(response.headers.location, /\/beacon\/bergen-to-court\/fsdakjhfdsjh$/)
+})
+
 test('requests the beacon page, w/o using a hash, at: `/beacon/mcs/`', async t => {
   const response = await server.inject({
     method: 'GET',


### PR DESCRIPTION
The glitch app redirects beacon requests to`/bergen/beacon/bergen/:beacon_hash`, which is not a valid URL.

This changeset sets up redirects for `GET` requests of the above form, so they will instead request `/beacon/bergen-to-court/${beacon_hash}`.

This redirects straight away to the beacon page for the route that the requestor wanted any ways, which is `bergen-to-route`

Background: `/beacon/bergen/${beacon_hash}` is an invalid URL, b/c `bergen` is actually a "meta" route, see #27 for more info