### PR TITLE
Fix testing GET response for location endpoint

### DIFF
--- a/test/server.test.js
+++ b/test/server.test.js
@@ -145,5 +145,5 @@ test(`POST and GET location for \`mcs\` route`, async t => {
     url: '/route/mcs/location'
   })
   t.equal(get_response.statusCode, 200, 'GET returns a status code of 200')
-  t.equal(post_response.body, JSON.stringify(location), "GET returns a body equal to POST'ed coordinates")
+  t.equal(get_response.body, JSON.stringify(location), "GET returns a body equal to POST'ed coordinates")
 })


### PR DESCRIPTION
Apparently we were testing the POST response, which happened to pass,
but isn't what we intend to test.

I discovered this while working on https://github.com/roosto/bikebus-nyc/pull/36