### PR TITLE
undo detour work

### DIFF
--- a/routes/bergen-to-court.json
+++ b/routes/bergen-to-court.json
@@ -89,95 +89,100 @@
             "markerClass" : "rotate-65",
             "name" : "Bedford Ave",
             "subtitle" : "",
-            "waypointOnly": true
-         },
-         {
-            "coordinates" : [
-         40.676810, -73.955762            ],
-            "markerClass" : "rotate-65",
-            "name" : "Franklin Ave",
             "time" : "7:40"
          },
          {
             "coordinates" : [
-               40.675061, -73.956382
-      ],
+               40.677523,
+               -73.959131
+            ],
             "markerClass" : "rotate-65",
-            "name" : "Prospect Pl"
-                  },
-                           {
-            "coordinates" : [
-               40.676543, -73.963525
-      ],
-            "markerClass" : "rotate-65",
-            "name" : "Prospect @ Washington",
-            "time": "7:45"
-                  },
-                  {
-            "coordinates" : [
-               40.677671, -73.968853
-      ],
-            "markerClass" : "rotate-65",
-            "name" : "Prospect @ Vanderbilt",
-            "time": "7:50"
-                  },
-                           {
-            "coordinates" : [
-               40.678605, -73.973262
-      ],
-            "markerClass" : "rotate-65",
-            "name" : "before Flatbush",
+            "name" : "Classon Av",
+            "subtitle" : "",
+            "time" : "",
             "waypointOnly": true
-                  },
-                           {
+         },
+         {
             "coordinates" : [
-               40.678776, -73.973885
-      ],
+               40.678175,
+               -73.962225
+            ],
             "markerClass" : "rotate-65",
-            "name" : "after Flatbush",
+            "name" : "Grand Av",
+            "subtitle" : "",
+            "time" : "7:45"
+         },
+         {
+            "coordinates" : [
+               40.67943,
+               -73.968222
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Vanderbilt Av",
+            "subtitle" : "",
+            "time" : "7:50"
+         },
+         {
+            "coordinates" : [
+               40.680749,
+               -73.974518
+            ],
+            "name" : "6th Ave",
             "waypointOnly": true
-                  },
-               {
+         },
+         {
             "coordinates" : [
-               40.680284, -73.977729
-      ],
-            "markerClass" : "rotate-65",
-            "name" : "before 5th Ave",
+               40.680876,
+               -73.975161
+            ],
+            "name" : "Flatbush",
             "waypointOnly": true
-                  },
-                           {
+         },
+         {
             "coordinates" : [
-               40.680269, -73.977980
-      ],
-            "markerClass" : "rotate-65",
-            "name" : "Prospect @ 5th Ave",
-            "time" : "7:55"
-                  },
-                           {
-            "coordinates" : [
-               40.681270, -73.980595
-
-      ],
-            "markerClass" : "rotate-65",
-            "name" : "Warren @ 4th Ave",
+               40.680875,
+               -73.975423
+            ],
+            "name" : "After bend east of Flatbush",
             "waypointOnly": true
-                  },
-                           {
+         },
+         {
             "coordinates" : [
-               40.683755, -73.987011
-      ],
+               40.681444, -73.976901
+            ],
+            "name" : "5th Ave",
             "markerClass" : "rotate-65",
-            "name" : "Warren @ Bond St",
-            "time" : "8:00"
-                  },
-                                             {
+            "waypointOnly": true
+         },
+         {
             "coordinates" : [
-               40.685456, -73.991331
-      ],
+               40.68254,
+               -73.97974
+            ],
+            "name" : "4th Ave",
             "markerClass" : "rotate-65",
-            "name" : "Warren @ Smith St",
+            "time": "7:55"
+         },
+         {
+            "coordinates" : [
+               40.685023,
+               -73.986139
+            ],
+            "markerClass" : "rotate-65",
+            "name": "",
+            "time" : "Bond St",
+            "subtitle" : ""
+         },
+         {
+            "coordinates" : [
+               40.687828,
+               -73.993264
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Court St",
+            "subtitle" : "",
             "time" : "8:05"
-                  }
+         }
       ],
       "trackerBounds" : {
          "bottomLeft" : [

--- a/routes/bergen-to-ps372.json
+++ b/routes/bergen-to-ps372.json
@@ -10,7 +10,8 @@
       "stops" : [
          {
             "coordinates" : [
-40.681224, -73.980461
+               40.68254,
+               -73.97974
             ],
             "name" : "4th Ave",
             "waypointOnly": true

--- a/routes/bergen.json
+++ b/routes/bergen.json
@@ -4,9 +4,7 @@
       "mapHeight" : "250px",
       "mapWidth" : "550px",
       "publish" : true,
-      "runInfo" : "Detour for June 18: left to go South on Franklin, then right to go West on Prospect Pl/Warren St with turns on 4th Ave, Bond, & Smith.",
-      "detour": true,
-      "detourInfo": "Note: Route is changed for June 18! West on Prospect Pl/Warren St after Franklin Ave",
+      "runInfo" : "Track the bike bus live on the map above beginning at 7:15am every Wednesday morning.",
       "title" : "Bergen Bike Bus",
       "trackerBounds" : {
          "bottomLeft" : [

--- a/routes/kidical-mass.json
+++ b/routes/kidical-mass.json
@@ -1,0 +1,112 @@
+{
+   "kidical-mass" : {
+      "color" : "#CC3333",
+      "mapHeight" : "1200px",
+      "mapWidth" : "1200px",
+      "runInfo" : "Track the bike bus live on the map above beginning at 7:00am every Wednesday morning.",
+      "publish" : false,
+      "stops" : [
+         {
+            "coordinates" :
+            [40.672905, -73.969868],
+            "markerClass" : "label-left"
+         },
+         {
+            "coordinates" : [
+  40.673073, -73.968730
+            ],
+            "name" : "First Stop on Eastern Parkwasy",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.672976, -73.967446
+            ],
+            "name" : "@ Underhill",
+            "waypointOnly" : true
+         },
+         {
+            "coordinates" : [
+40.672676, -73.966021
+            ],
+            "name" : "@ Washington",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.671792, -73.962744            ],
+            "name" : "@ Classon",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.670806, -73.957921
+            ],
+            "name" : "@ Franklin",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.670244, -73.955233            ],
+            "name" : "@ Bedford",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.670147, -73.953263            ],
+            "name" : "@ Rogers",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.669843, -73.947730            ],
+            "name" : "@ New York Ave",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.669548, -73.942209            ]
+         },
+         {
+            "coordinates" : [
+40.672955, -73.941859            ],
+            "name" : "Kingston @ Park Pl",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.674768, -73.941691            ],
+            "name" : " ",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.674606, -73.938921            ],
+            "name" : "St. Marks @ Albany Ave",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.674489, -73.936300            ],
+            "name" : "St. Marks @ Troy Ave (Albany Houses side)",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.674317, -73.934851            ]
+         }
+      ],
+      "title" : "Bergen Bike Bus Tracker",
+      "trackerBounds" : {
+         "bottomLeft" : [
+            40.685828,
+            -73.91115
+         ],
+         "topRight" : [
+            40.667982,
+            -73.991364
+         ]
+      },
+      "trackerTileSrcPattern" : "https://cdn.glitch.global/063a0a5f-eb87-40ce-a77a-c3851de5a1b6/bergen.10.05.22.{z}.{x}.{y}.png"
+   }
+}


### PR DESCRIPTION
this commit undoes the detour that was put on for June 18

This does keep the `detour` `if` detour part of that was added for the `tracker.hbs` page