### PR TITLE
Revert the Sept 24 "detour" for `bergen` route

### DIFF
--- a/routes/bergen-princi-breaky.json
+++ b/routes/bergen-princi-breaky.json
@@ -1,0 +1,185 @@
+{
+  "bergen-princi-breaky": {
+    "color": "#EFB143",
+    "mapHeight": "250px",
+    "mapWidth": "550px",
+    "publish": false,
+    "runInfo": "Bergen Bike Brunch on Sept 24: Ride to Principles GI Coffee House",
+    "detour": true,
+    "detourInfo": "Note: Route and time change this week: start at 8am, no route to Court, PS 372 route continues to 8th St & then west to 2nd Ave & Principles GI Coffee House!",
+    "title": "Bergen Bike Brunch @ Principles",
+    "trackerBounds": {
+      "bottomLeft": [40.685828, -73.91115],
+      "topRight": [40.667982, -73.991364]
+    },
+    "stops": [
+      {
+        "coordinates": [40.673982, -73.91115],
+        "markerClass": "rotate-65",
+        "name": "Rockaway Ave @ Bergen",
+        "subtitle": "",
+        "time": "8:00"
+      },
+      {
+        "coordinates": [40.674448, -73.919458],
+        "markerClass": "rotate-65",
+        "name": "Howard Ave",
+        "time": "",
+        "waypointOnly": true
+      },
+      {
+        "coordinates": [40.676007, -73.919316],
+        "markerClass": "rotate-65",
+        "name": "Howard Ave @ Pacific",
+        "time": ""
+      },
+      {
+        "coordinates": [40.676329, -73.925284],
+        "markerClass": "rotate-65",
+        "name": "Kingsborough Houses",
+        "time": ""
+      },
+      {
+        "coordinates": [40.674783, -73.925458],
+        "markerClass": "rotate-65",
+        "name": "Kingsborough Houses @ Bergen",
+        "time": "",
+        "waypointOnly": true
+      },
+      {
+        "coordinates": [40.67505, -73.930545],
+        "markerClass": "rotate-65",
+        "name": "Utica Ave @ Bergen",
+        "subtitle": "",
+        "time": ""
+      },
+      {
+        "coordinates": [40.675787, -73.94439],
+        "markerClass": "rotate-65",
+        "name": "Brooklyn Ave",
+        "subtitle": "",
+        "time": "8:15"
+      },
+      {
+        "coordinates": [40.67625, -73.952636],
+        "markerClass": "rotate-65",
+        "name": "Rogers Ave",
+        "subtitle": "",
+        "time": "",
+        "waypointOnly": true
+      },
+      {
+        "coordinates": [40.676271, -73.953047],
+        "markerClass": "rotate-65",
+        "name": "Bedford Ave",
+        "subtitle": "",
+        "time": ""
+      },
+      {
+        "coordinates": [40.677523, -73.959131],
+        "markerClass": "rotate-65",
+        "name": "Classon Av",
+        "subtitle": "",
+        "time": "",
+        "waypointOnly": true
+      },
+      {
+        "coordinates": [40.678175, -73.962225],
+        "markerClass": "rotate-65",
+        "name": "Grand Av",
+        "subtitle": "",
+        "time": "8:25",
+        "waypointOnly": false
+      },
+      {
+        "coordinates": [40.67943, -73.968222],
+        "markerClass": "rotate-65",
+        "name": "Vanderbilt Av",
+        "subtitle": "",
+        "time": ""
+      },
+      {
+        "coordinates": [40.680749, -73.974518],
+        "name": "6th Ave",
+        "waypointOnly": true
+      },
+      {
+        "coordinates": [40.680876, -73.975161],
+        "name": "Flatbush",
+        "waypointOnly": true
+      },
+      {
+        "coordinates": [40.680875, -73.975423],
+        "name": "After bend east of Flatbush",
+        "waypointOnly": true
+      },
+      {
+        "coordinates": [40.681444, -73.976901],
+        "name": "5th Ave",
+        "markerClass": "rotate-65",
+        "waypointOnly": true
+      },
+      {
+        "coordinates": [40.68254, -73.97974],
+        "name": "4th Ave",
+        "markerClass": "rotate-65",
+        "time": "8:35",
+        "waypointOnly": false
+      },
+      {
+        "coordinates": [40.68254, -73.97974],
+        "name": "4th Ave",
+        "waypointOnly": true
+      },
+      {
+        "coordinates": [40.680536, -73.98097],
+        "name": "PS 133",
+        "waypointOnly": true
+      },
+      {
+        "coordinates": [40.67742, -73.983035],
+        "name": "Union St",
+        "markerClass": "rotate-65",
+        "time": "8:40",
+        "waypointOnly": false
+      },
+      {
+        "coordinates": [40.676167, -73.983895],
+        "name": "4th Ave @ Carroll",
+        "waypointOnly": true
+      },
+      {
+        "coordinates": [40.673958, -73.985703],
+        "name": "3rd St",
+        "waypointOnly": true
+      },
+      {
+        "coordinates": [40.670972, -73.988218],
+        "name": "8th St",
+        "markerClass": "rotate-65",
+        "waypointOnly": false
+      },
+      {
+        "coordinates": [40.673227, -73.992922],
+        "name": "8th St @ 2nd Ave",
+        "waypointOnly": true
+      },
+      {
+        "coordinates": [40.672615, -73.993389],
+        "name": "2nd Ave @ 9th st",
+        "waypointOnly": true
+      },
+      {
+        "coordinates": [40.672321, -73.992745],
+        "name": "Principles!",
+        "markerClass": "rotate-65",
+        "waypointOnly": false
+      }
+    ],
+    "trackerBounds": {
+      "bottomLeft": [40.685828, -73.91115],
+      "topRight": [40.667982, -73.991364]
+    },
+    "trackerTileSrcPattern": "https://cdn.glitch.global/063a0a5f-eb87-40ce-a77a-c3851de5a1b6/bergen.10.05.22.{z}.{x}.{y}.png"
+  }
+}

--- a/routes/bergen-to-court.json
+++ b/routes/bergen-to-court.json
@@ -1,131 +1,199 @@
 {
-  "bergen-to-court": {
-    "color": "#EFB143",
-    "mapHeight": "250px",
-    "mapWidth": "550px",
-    "runInfo": "Track the bike bus live on the map above beginning at 7:15am every Wednesday morning.",
-    "publish": false,
-    "title": "Bergen Bike Bus: Court St Branch",
-    "parentMetaRoute": "bergen",
-    "stops": [
-      {
-        "coordinates": [40.673982, -73.91115],
-        "markerClass": "rotate-65",
-        "name": "Rockaway Ave @ Bergen",
-        "subtitle": "",
-        "time": "8:00"
+   "bergen-to-court" : {
+      "color" : "#EFB143",
+      "mapHeight" : "250px",
+      "mapWidth" : "550px",
+      "runInfo" : "Track the bike bus live on the map above beginning at 7:15am every Wednesday morning.",
+      "publish" : false,
+      "title" : "Bergen Bike Bus: Court St Branch",
+      "parentMetaRoute": "bergen",
+      "stops" : [
+         {
+            "coordinates" : [
+               40.673982,
+               -73.91115
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Rockaway Ave @ Bergen",
+            "subtitle" : "",
+            "time" : "7:15-7:20"
+         },
+         {
+            "coordinates" : [
+               40.674448,
+               -73.919458
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Howard Ave",
+            "time" : "",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.676007, -73.919316
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Howard Ave @ Pacific",
+            "time" : "7:25"
+         },
+         {
+            "coordinates" : [
+40.676329, -73.925284
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Kingsborough Houses",
+            "time" : ""
+         },
+         {
+            "coordinates" : [
+40.674783, -73.925458
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Kingsborough Houses @ Bergen",
+            "time" : "",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.675050, -73.930545
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Utica Ave @ Bergen",
+            "subtitle" : "",
+            "time" : "7:30"
+         },
+                  {
+            "coordinates" : [
+               40.675787,
+               -73.94439
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Brooklyn Ave",
+            "subtitle" : "",
+            "time" : "7:35"
+         },
+         {
+            "coordinates" : [
+40.676250, -73.952636
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Rogers Ave",
+            "subtitle" : "",
+            "time" : "",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+40.676271, -73.953047
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Bedford Ave",
+            "subtitle" : "",
+            "time" : "7:40"
+         },
+         {
+            "coordinates" : [
+               40.677523,
+               -73.959131
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Classon Av",
+            "subtitle" : "",
+            "time" : "",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+               40.678175,
+               -73.962225
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Grand Av",
+            "subtitle" : "",
+            "time" : "7:45"
+         },
+         {
+            "coordinates" : [
+               40.67943,
+               -73.968222
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Vanderbilt Av",
+            "subtitle" : "",
+            "time" : "7:50"
+         },
+         {
+            "coordinates" : [
+               40.680749,
+               -73.974518
+            ],
+            "name" : "6th Ave",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+               40.680876,
+               -73.975161
+            ],
+            "name" : "Flatbush",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+               40.680875,
+               -73.975423
+            ],
+            "name" : "After bend east of Flatbush",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+               40.681444, -73.976901
+            ],
+            "name" : "5th Ave",
+            "markerClass" : "rotate-65",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+               40.68254,
+               -73.97974
+            ],
+            "name" : "4th Ave",
+            "markerClass" : "rotate-65",
+            "time": "7:55"
+         },
+         {
+            "coordinates" : [
+               40.685023,
+               -73.986139
+            ],
+            "markerClass" : "rotate-65",
+            "name": "",
+            "time" : "Bond St",
+            "subtitle" : ""
+         },
+         {
+            "coordinates" : [
+               40.687828,
+               -73.993264
+            ],
+            "markerClass" : "rotate-65",
+            "name" : "Court St",
+            "subtitle" : "",
+            "time" : "8:05"
+         }
+      ],
+      "trackerBounds" : {
+         "bottomLeft" : [
+            40.685828,
+            -73.91115
+         ],
+         "topRight" : [
+            40.667982,
+            -73.991364
+         ]
       },
-      {
-        "coordinates": [40.674448, -73.919458],
-        "markerClass": "rotate-65",
-        "name": "Howard Ave",
-        "time": "",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.676007, -73.919316],
-        "markerClass": "rotate-65",
-        "name": "Howard Ave @ Pacific",
-        "time": ""
-      },
-      {
-        "coordinates": [40.676329, -73.925284],
-        "markerClass": "rotate-65",
-        "name": "Kingsborough Houses",
-        "time": ""
-      },
-      {
-        "coordinates": [40.674783, -73.925458],
-        "markerClass": "rotate-65",
-        "name": "Kingsborough Houses @ Bergen",
-        "time": "",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.67505, -73.930545],
-        "markerClass": "rotate-65",
-        "name": "Utica Ave @ Bergen",
-        "subtitle": "",
-        "time": ""
-      },
-      {
-        "coordinates": [40.675787, -73.94439],
-        "markerClass": "rotate-65",
-        "name": "Brooklyn Ave",
-        "subtitle": "",
-        "time": "8:15"
-      },
-      {
-        "coordinates": [40.67625, -73.952636],
-        "markerClass": "rotate-65",
-        "name": "Rogers Ave",
-        "subtitle": "",
-        "time": "",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.676271, -73.953047],
-        "markerClass": "rotate-65",
-        "name": "Bedford Ave",
-        "subtitle": "",
-        "time": ""
-      },
-      {
-        "coordinates": [40.677523, -73.959131],
-        "markerClass": "rotate-65",
-        "name": "Classon Av",
-        "subtitle": "",
-        "time": "",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.678175, -73.962225],
-        "markerClass": "rotate-65",
-        "name": "Grand Av",
-        "subtitle": "",
-        "time": "8:25",
-        "waypointOnly": false
-      },
-      {
-        "coordinates": [40.67943, -73.968222],
-        "markerClass": "rotate-65",
-        "name": "Vanderbilt Av",
-        "subtitle": "",
-        "time": ""
-      },
-      {
-        "coordinates": [40.680749, -73.974518],
-        "name": "6th Ave",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.680876, -73.975161],
-        "name": "Flatbush",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.680875, -73.975423],
-        "name": "After bend east of Flatbush",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.681444, -73.976901],
-        "name": "5th Ave",
-        "markerClass": "rotate-65",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.68254, -73.97974],
-        "name": "4th Ave",
-        "markerClass": "rotate-65",
-        "time": "8:35",
-        "waypointOnly": false
-      }
-    ],
-    "trackerBounds": {
-      "bottomLeft": [40.685828, -73.91115],
-      "topRight": [40.667982, -73.991364]
-    },
-    "trackerTileSrcPattern": "https://cdn.glitch.global/063a0a5f-eb87-40ce-a77a-c3851de5a1b6/bergen.10.05.22.{z}.{x}.{y}.png"
-  }
+      "trackerTileSrcPattern" : "https://cdn.glitch.global/063a0a5f-eb87-40ce-a77a-c3851de5a1b6/bergen.10.05.22.{z}.{x}.{y}.png"
+   }
 }

--- a/routes/bergen-to-ps372.json
+++ b/routes/bergen-to-ps372.json
@@ -1,67 +1,64 @@
 {
-  "bergen-to-ps372": {
-    "color": "#EFB143",
-    "mapHeight": "250px",
-    "mapWidth": "550px",
-    "runInfo": "Track the bike bus live on the map above beginning at 7:15am every Wednesday morning.",
-    "publish": false,
-    "title": "Bergen Bike Bus: PS 372 Branch",
-    "parentMetaRoute": "bergen",
-    "stops": [
-      {
-        "coordinates": [40.68254, -73.97974],
-        "name": "4th Ave",
-        "waypointOnly": true
+   "bergen-to-ps372" : {
+      "color" : "#EFB143",
+      "mapHeight" : "250px",
+      "mapWidth" : "550px",
+      "runInfo" : "Track the bike bus live on the map above beginning at 7:15am every Wednesday morning.",
+      "publish" : false,
+      "title" : "Bergen Bike Bus: PS 372 Branch",
+      "parentMetaRoute": "bergen",
+      "stops" : [
+         {
+            "coordinates" : [
+               40.68254,
+               -73.97974
+            ],
+            "name" : "4th Ave",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+               40.680536,
+               -73.98097
+            ],
+            "name" : "PS 133",
+            "waypointOnly": true
+         },
+         {
+            "coordinates" : [
+               40.67742,
+               -73.983035
+            ],
+            "name" : "4th Ave @ Union St",
+            "waypointOnly" : true
+         },
+         {
+            "coordinates" : [
+               40.676167,
+               -73.983895
+            ],
+            "name" : "4th Ave @ Carroll",
+            "waypointOnly" : true
+         },
+         {
+            "coordinates" : [
+40.676618, -73.985118
+            ],
+            "name" : "PS 372",
+            "markerClass" : "rotate-65",
+            "time" : "8:05"
+         }
+      ],
+      "trackerBounds" : {
+         "bottomLeft" : [
+            40.685828,
+            -73.91115
+         ],
+         "topRight" : [
+            40.667982,
+            -73.991364
+         ]
       },
-      {
-        "coordinates": [40.680536, -73.98097],
-        "name": "PS 133",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.67742, -73.983035],
-        "name": "Union St",
-        "markerClass": "rotate-65",
-        "time": "8:40",
-        "waypointOnly": false
-      },
-      {
-        "coordinates": [40.676167, -73.983895],
-        "name": "4th Ave @ Carroll",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.673958, -73.985703],
-        "name": "3rd St",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.670972, -73.988218],
-        "name": "8th St",
-        "markerClass": "rotate-65",
-        "waypointOnly": false
-      },
-      {
-        "coordinates": [40.673227, -73.992922],
-        "name": "8th St @ 2nd Ave",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.672615, -73.993389],
-        "name": "2nd Ave @ 9th st",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.672321, -73.992745],
-        "name": "Principles!",
-        "markerClass": "rotate-65",
-        "waypointOnly": false
-      }
-    ],
-    "trackerBounds": {
-      "bottomLeft": [40.685828, -73.91115],
-      "topRight": [40.667982, -73.991364]
-    },
-    "trackerTileSrcPattern": "https://cdn.glitch.global/063a0a5f-eb87-40ce-a77a-c3851de5a1b6/bergen.10.05.22.{z}.{x}.{y}.png"
-  }
+      "trackerTileSrcPattern" : "https://cdn.glitch.global/063a0a5f-eb87-40ce-a77a-c3851de5a1b6/bergen.10.05.22.{z}.{x}.{y}.png"
+   }
 }

--- a/routes/bergen.json
+++ b/routes/bergen.json
@@ -1,17 +1,21 @@
 {
-  "bergen": {
-    "color": "#EFB143",
-    "mapHeight": "250px",
-    "mapWidth": "550px",
-    "publish": true,
-    "runInfo": "Bergen Bike Brunch on Sept 24: Ride to Principles GI Coffee House",
-    "detour": true,
-    "detourInfo": "Note: Route and time change for Sept 24: start at 8am, no route to Court, PS 372 route continues to 8th St & then west to 2nd Ave & Principles GI Coffee House!",
-    "title": "Bergen Bike Bus",
-    "trackerBounds": {
-      "bottomLeft": [40.685828, -73.91115],
-      "topRight": [40.667982, -73.991364]
-    },
-    "combinedRouteKeys": ["bergen-to-court", "bergen-to-ps372"]
-  }
+   "bergen" : {
+      "color" : "#EFB143",
+      "mapHeight" : "250px",
+      "mapWidth" : "550px",
+      "publish" : true,
+      "runInfo" : "Track the bike bus live on the map above beginning at 7:15am every Wednesday morning.",
+      "title" : "Bergen Bike Bus",
+      "trackerBounds" : {
+         "bottomLeft" : [
+            40.685828,
+            -73.91115
+         ],
+         "topRight" : [
+            40.667982,
+            -73.991364
+         ]
+      },
+      "combinedRouteKeys" : ["bergen-to-court", "bergen-to-ps372"]
+   }
 }


### PR DESCRIPTION
I reverted the Bergen-related JSON route files, so we are back to normal/usual route

I also did save the route w/ the ride to Princi so it's easy to swap in for the next time we do a breakfast ride.