### PR TITLE
Work Island reroute via Prince

### DIFF
--- a/routes/work-island.json
+++ b/routes/work-island.json
@@ -181,7 +181,8 @@
   {
     "coordinates": [40.726973, -74.003442],
     "name": "Prince @ 6th Ave",
-    "waypointOnly": false
+    "waypointOnly": false,
+    "time": "8:50"
   },
   {
     "coordinates": [40.731718, -74.000960],
@@ -191,7 +192,8 @@
   {
     "coordinates": [40.737357, -73.996839],
     "name": "6th Ave @ 14th",
-    "waypointOnly": false
+    "waypointOnly": false,
+    "time": "9:00"
   },
 
       {

--- a/routes/work-island.json
+++ b/routes/work-island.json
@@ -149,7 +149,7 @@
       {
         "coordinates": [40.721466, -73.997393],
         "name": "Lafayette @ Kenmare",
-        "waypointOnly": false
+        "waypointOnly": true
       },
       {
         "coordinates": [40.722317, -73.997129],
@@ -157,57 +157,43 @@
         "waypointOnly": true
       },
       {
+        "coordinates": [40.723492, -73.996659],
+        "name": "lafayette *just* south of Prince",
+        "waypointOnly": true
+      },
+      {
         "coordinates": [40.723693, -73.996472],
         "name": "Lafayette @ Prince",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.725933, -73.994637],
-        "name": "Lafayette @ Bleeker",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.729862, -73.991420],
-        "name": "Lafayette @ Astor Pl",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.730591, -73.990559],
-        "name": "Astor Place",
-        "waypointOnly": false,
-        "time": "8:50"
-      },
-      {
-        "coordinates": [40.733524, -73.989869],
-        "name": "Lafayette @ Wanamaker",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.735327, -73.989905],
-        "name": "4th Ave @ 15th St",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.736566, -73.989026],
-        "name": "4th Ave @ 17th St",
-        "waypointOnly": true
-      },
-        {
-        "coordinates": [40.737116, -73.990283],
-        "name": "17th & Broadway",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.739878, -73.989590],
-        "name": "Broadway @ 21st",
-        "waypointOnly": true
-      },
-      {
-        "coordinates": [40.741629, -73.993740],
-        "name": "21st @ 6th Ave",
-        "markerClass": "label-left push-up-4x",
         "waypointOnly": false
       },
+
+
+  {
+    "coordinates": [40.724233, -73.997799],
+    "name": "Prince @ Broadway",
+    "waypointOnly": true
+  },
+  {
+    "coordinates": [40.726981, -74.003432],
+    "name": "Prince @ MacDougal (*just* East of 6th Ave)",
+    "waypointOnly": true
+  },
+  {
+    "coordinates": [40.726973, -74.003442],
+    "name": "Prince @ 6th Ave",
+    "waypointOnly": false
+  },
+  {
+    "coordinates": [40.731718, -74.000960],
+    "name": "6th Ave @ W 4th",
+    "waypointOnly": true
+  },
+  {
+    "coordinates": [40.737357, -73.996839],
+    "name": "6th Ave @ 14th",
+    "waypointOnly": false
+  },
+
       {
         "coordinates": [40.744813, -73.991403],
         "name": "6th Ave @ 26th",


### PR DESCRIPTION
Temporary (maybe permanent?) re-route of the Bus to go west to 6th Ave from Lafayette using Prince St.

This version is a little rough, but it's useable!